### PR TITLE
usb_sniffer: fixed trying to write rst update when sniffer is not ena…

### DIFF
--- a/usb_sniffer/rtl/usb_sniffer.v
+++ b/usb_sniffer/rtl/usb_sniffer.v
@@ -365,7 +365,7 @@ begin
                 next_state_r  = STATE_RX_DATA_IGNORE;
         end
         // Reset state change, record status
-        else if (rst_change_w && !buffer_full_w)
+        else if (rst_change_w && !buffer_full_w && cfg_enabled_w)
             next_state_r  = STATE_UPDATE_RST;
     end
 


### PR DESCRIPTION
…bled

Previous behaviour before this fix has two consequences:

1. First cell in memory is filled without cfg_enabled.
2. Since after that write_detect_q is on then it causes buffer_full_q on
   without cfg_enabled. Later after sniffer enabling we get buffer_full_clr_w
   and next_addr_q jumps over cell with address 4. It means that we always
   get:

ERROR: Unknown ID 0 position 4